### PR TITLE
Fixes the issue with latest NGC PyTorch containers that come with python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'distributed==2021.7.1',
         'dask-mpi==2021.11.0',
         'bokeh==2.4.3',
-        'pyarrow==4.0.1',
+        'pyarrow>=4.0.1',
         'mpi4py==3.1.3',
         'transformers==4.16.2',
         'wikiextractor==3.0.6',


### PR DESCRIPTION
The current hard constraint in the setup.py file for pyarrow (pyarrow==4.0.1) breaks the builds on containers that have python 3.10. This merge request relaxes that constraint so that newer versions of pyarrow can be installed which prevents the build failure for the nightly containers.
