### PR TITLE
Fix issues

### DIFF
--- a/lddl/paddle/datasets.py
+++ b/lddl/paddle/datasets.py
@@ -31,9 +31,9 @@ import paddle
 
 from paddle.io import IterableDataset, get_worker_info
 try:
-    from paddle.base.framework import in_dygraph_mode
+  from paddle.base.framework import in_dygraph_mode
 except ImportError:
-    from paddle.fluid.framework import in_dygraph_mode
+  from paddle.fluid.framework import in_dygraph_mode
 
 from lddl.types import File
 from lddl.utils import get_num_samples_of_parquet
@@ -92,9 +92,10 @@ class ShuffleBuffer:
         for isample in self._decode_record_batch(b):
           if remaining_num_samples <= 0:
             return
-          if (len(buffer) >= min(
-              self._size, (num_samples_to_yield - remaining_num_samples + 1) *
-              self._warmup_factor)):
+          if (len(buffer)
+              >= min(self._size,
+                     (num_samples_to_yield - remaining_num_samples + 1) *
+                     self._warmup_factor)):
             replace_idx = self._randrange(len(buffer))
             yield buffer[replace_idx]
             buffer[replace_idx] = isample

--- a/lddl/paddle/datasets.py
+++ b/lddl/paddle/datasets.py
@@ -30,7 +30,10 @@ import random
 import paddle
 
 from paddle.io import IterableDataset, get_worker_info
-from paddle.fluid.framework import in_dygraph_mode
+try:
+    from paddle.base.framework import in_dygraph_mode
+except ImportError:
+    from paddle.fluid.framework import in_dygraph_mode
 
 from lddl.types import File
 from lddl.utils import get_num_samples_of_parquet

--- a/lddl/paddle/utils.py
+++ b/lddl/paddle/utils.py
@@ -25,11 +25,11 @@
 import os
 import paddle
 try:
-    from paddle.base.framework import in_dygraph_mode
-    from paddle.base import unique_name, core
+  from paddle.base.framework import in_dygraph_mode
+  from paddle.base import unique_name, core
 except ImportError:
-    from paddle.fluid.framework import in_dygraph_mode
-    from paddle.fluid import unique_name, core
+  from paddle.fluid.framework import in_dygraph_mode
+  from paddle.fluid import unique_name, core
 from paddle.distributed.fleet.base.private_helper_function import wait_server_ready
 
 

--- a/lddl/paddle/utils.py
+++ b/lddl/paddle/utils.py
@@ -24,7 +24,12 @@
 
 import os
 import paddle
-from paddle.fluid.framework import in_dygraph_mode
+try:
+    from paddle.base.framework import in_dygraph_mode
+    from paddle.base import unique_name, core
+except ImportError:
+    from paddle.fluid.framework import in_dygraph_mode
+    from paddle.fluid import unique_name, core
 from paddle.distributed.fleet.base.private_helper_function import wait_server_ready
 
 
@@ -108,9 +113,9 @@ def all_reduce_in_static_mode(local_tensor, reduce_op):
 
   block = startup_program.global_block()
   nccl_id_var = block.create_var(
-      name=paddle.fluid.unique_name.generate('nccl_id'),
+      name=unique_name.generate('nccl_id'),
       persistable=True,
-      type=paddle.fluid.core.VarDesc.VarType.RAW,
+      type=core.VarDesc.VarType.RAW,
   )
 
   block.append_op(

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'distributed==2021.7.1',
         'dask-mpi==2021.11.0',
         'bokeh==2.4.3',
-        'pyarrow>=4.0.1',
+        'pyarrow==14.0.1',
         'mpi4py==3.1.3',
         'transformers==4.16.2',
         'wikiextractor==3.0.6',


### PR DESCRIPTION
- Fix import error. In Paddle2.6, `paddle.fluid` is deprecated and replaced by `paddle.base`. 
- Dask needs to import `ParquetDatasetPiece`, which is deprecated in the latest PyArrow v15.0.1. So I fix the PyArrow version to v14.0.1. 
![image](https://github.com/NVIDIA/LDDL/assets/21985950/5410b854-2e9f-426c-8ce6-184f6e527095)

