### PR TITLE
Update dependencies to work with python3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'dask-mpi==2021.11.0',
         'bokeh==2.4.3',
         'pyarrow==14.0.1',
-        'mpi4py==3.1.3',
+        'mpi4py==3.1.6',
         'transformers==4.16.2',
         'wikiextractor==3.0.6',
         'news-please @ git+https://github.com/fhamborg/news-please.git@3b7d9fdfeb148ef73f393bb2f2557e6bd878a09f',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'news-please @ git+https://github.com/fhamborg/news-please.git@3b7d9fdfeb148ef73f393bb2f2557e6bd878a09f',
         'cchardet==2.1.7',
         'awscli>=1.22.55',
-        'wikiextractor @ git+https://github.com/attardi/wikiextractor.git@v3.0.6',
+        'wikiextractor==3.0.6',
         'gdown==4.5.3',
     ],
     entry_points={


### PR DESCRIPTION
- Changed the install of wikiextractor not to use github, as this failed with python3.12
- Upgraded mpi4py to 3.1.6, which supports python3.12